### PR TITLE
Handle serve order columns consistently

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -14,7 +14,9 @@ GG_TEAMMATES_SHEETS    = {"gg teammates", "ggteammates"}
 ORDERS_COUNT_SHEETS    = {"orders count"}
 clients_SHEETS       = {"clients"}
 # New identifiers for serve orders and cancellations
-ORDERS_HISTORY_COLUMN = "accepted_interval"
+# Columns may come in various forms like "AcceptedInterval" or "accepted_interval".
+# Use the normalized name that ``standardize_columns`` would produce.
+ORDERS_HISTORY_COLUMN = "acceptedinterval"
 CANCELLATIONS_COLUMN  = "canceldate"
 # ──────────────────────────────────────────────────────────────────────────────
 # Логирование
@@ -117,6 +119,8 @@ def load_data_from_file(path: str) -> dict:
         for sheet in xls.sheet_names:
             sl = sheet.lower()
             df = pd.read_excel(xls, sheet_name=sheet)
+            # Drop any automatically generated "Unnamed" columns
+            df = df.loc[:, ~df.columns.str.lower().str.startswith("unnamed")]
             df = standardize_columns(df)
 
             # check for serve orders and cancellation sheets by column names
@@ -185,6 +189,7 @@ def load_data_from_file(path: str) -> dict:
     elif ext == "csv":
         # если нужен CSV
         df = pd.read_csv(path)
+        df = df.loc[:, ~df.columns.str.lower().str.startswith("unnamed")]
         df = standardize_columns(df)
         if "date" in df.columns:
             df["date"] = robust_parse_dates(df["date"], path)

--- a/modules/BusinessModule/ggBusinessTabs/serveAnalyzeTab.py
+++ b/modules/BusinessModule/ggBusinessTabs/serveAnalyzeTab.py
@@ -55,8 +55,8 @@ def show(data: dict, filters: dict) -> None:
     if "orderdate1" in orders.columns:
         orders["orderdate1"] = pd.to_datetime(orders["orderdate1"], errors="coerce")
 
-    orders["accepted_seconds"] = orders.get("accepted_interval").apply(_parse_interval_seconds)
-    orders["arrived_minutes"] = orders.get("arrived_interval").apply(_parse_interval_seconds) / 60.0
+    orders["accepted_seconds"] = orders.get("acceptedinterval").apply(_parse_interval_seconds)
+    orders["arrived_minutes"] = orders.get("arrivedinterval").apply(_parse_interval_seconds) / 60.0
     orders["distance"] = pd.to_numeric(orders.get("distance"), errors="coerce")
     orders["fare"] = pd.to_numeric(orders.get("fare"), errors="coerce")
 


### PR DESCRIPTION
## Summary
- standardize the serve orders history column name
- drop Excel `Unnamed` columns when loading files
- update serve analyzer to use normalized column names

## Testing
- `python -m py_compile data_loader.py modules/BusinessModule/ggBusinessTabs/serveAnalyzeTab.py`

------
https://chatgpt.com/codex/tasks/task_e_684805fb21b8832b90cc3ff4835a1ef4