### PR TITLE
fix serve orders concat

### DIFF
--- a/data_loader.py
+++ b/data_loader.py
@@ -51,7 +51,12 @@ def standardize_columns(df: pd.DataFrame) -> pd.DataFrame:
             df[col] = df[col].astype(str).str.lower()
         else:
             mapping[col] = norm
-    return df.rename(columns=mapping)
+    df = df.rename(columns=mapping)
+    if df.columns.duplicated().any():
+        dupes = list(df.columns[df.columns.duplicated()])
+        logger.warning("Duplicate column names %s found; keeping first occurrence", dupes)
+        df = df.loc[:, ~df.columns.duplicated()]
+    return df
 
 def custom_parse_date(s: str) -> pd.Timestamp:
     try:


### PR DESCRIPTION
## Summary
- drop duplicate columns in `standardize_columns` to avoid `InvalidIndexError`

## Testing
- `python -m py_compile data_loader.py modules/BusinessModule/ggBusinessData.py`

------
https://chatgpt.com/codex/tasks/task_e_68480e253458832bbdc112f992e111bd